### PR TITLE
Fix encrypted repo settings so newer versions of git don't complain about corrupted repo

### DIFF
--- a/myba.sh
+++ b/myba.sh
@@ -261,6 +261,7 @@ cmd_init () {
     git_enc config fetch.parallel 4
     git_enc config advice.detachedHead false  # Subprocedures do detached-head checkouts
     git_enc config init.defaultBranch master
+    git_enc config core.commitGraph false
     # Set up default gitignore
     echo "$default_gitignore" > "$PLAIN_REPO/info/exclude"
 

--- a/myba.sh
+++ b/myba.sh
@@ -261,7 +261,7 @@ cmd_init () {
     git_enc config fetch.parallel 4
     git_enc config advice.detachedHead false  # Subprocedures do detached-head checkouts
     git_enc config init.defaultBranch master
-    git_enc config core.commitGraph false
+    git_enc config core.commitGraph false  # File deletions performed by cmd_gc are not compatible with having a commit graph
     # Set up default gitignore
     echo "$default_gitignore" > "$PLAIN_REPO/info/exclude"
 

--- a/smoke-test.sh
+++ b/smoke-test.sh
@@ -66,7 +66,7 @@ myba push
 export PAGER=
 myba log
 
-# Test to make https://github.com/kernc/myba/issues/1 easier to detect
+# Ensure git is still satisfied with the integrity of the encrypted repository after gc from `myba push`
 myba git_enc log || exit 15
 
 title 'Somewhere else, much, much later ...'

--- a/smoke-test.sh
+++ b/smoke-test.sh
@@ -66,6 +66,9 @@ myba push
 export PAGER=
 myba log
 
+# Test to make https://github.com/kernc/myba/issues/1 easier to detect
+myba git_enc log || exit 15
+
 title 'Somewhere else, much, much later ...'
 
 WORK_TREE="$HOME/restore"  # From here on, $WORK_TREE overrides $HOME


### PR DESCRIPTION
For the encrypted repo, myba gc is removing internal git files. Newer versions of git do not like this and complain about the repo being corrupted.

Disabling the commit graph for the encrypted repo resolves the issue even for new git versions (tested with version 2.51.0). Fixes #1. 