### PR TITLE
Don't allow the WORK_TREE to leak in from outside the smoke test

### DIFF
--- a/smoke-test.sh
+++ b/smoke-test.sh
@@ -21,6 +21,8 @@ disk_usage () { du -t 10K -h "$HOME" | sort -h; }
 export KDF_ITERS=100  # Much faster encryption
 
 # Prepare test
+# Isolate the smoke test from any WORK_TREE the user might have exported
+export WORK_TREE=
 # $HOME is the default WORK_TREE dir
 HOME="$(mktemp -d -t myba-test-XXXXXXX)"
 export HOME

--- a/smoke-test.sh
+++ b/smoke-test.sh
@@ -22,7 +22,7 @@ export KDF_ITERS=100  # Much faster encryption
 
 # Prepare test
 # Isolate the smoke test from any WORK_TREE the user might have exported
-export WORK_TREE=
+unset WORK_TREE
 # $HOME is the default WORK_TREE dir
 HOME="$(mktemp -d -t myba-test-XXXXXXX)"
 export HOME


### PR DESCRIPTION
Ensure the smoke test uses its own test repository even if a user runs the smoke test while having `WORK_TREE` set for a "real" myba repository.